### PR TITLE
Logspam issue and optionally allow remote lidarr instance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+build.sh
+build.cmd

--- a/root/etc/services.d/extended/run
+++ b/root/etc/services.d/extended/run
@@ -11,7 +11,7 @@ echo "Project: https://github.com/RandomNinjaAtk/docker-lidarr-extended"
 echo "Support: https://github.com/RandomNinjaAtk/docker-lidarr-extended/discussions"
 echo "-----------------------------------------------------------------------------"
 
-if [ "$autoStart" = "true" ]; then
+if [ "$autoStart" = "true" ] && [ "$enableAudioScript" = "true" ]; then
 	echo "Automatic Start Enabled, starting in 2 min..."
 	sleep 2m
 	bash /config/extended/scripts/start_audio.sh

--- a/root/etc/services.d/extended_video/run
+++ b/root/etc/services.d/extended_video/run
@@ -10,7 +10,7 @@ echo "Donate: https://github.com/sponsors/RandomNinjaAtk"
 echo "Project: https://github.com/RandomNinjaAtk/docker-lidarr-extended"
 echo "Support: https://github.com/RandomNinjaAtk/docker-lidarr-extended/discussions"
 echo "-----------------------------------------------------------------------------"
-if [ "$autoStart" = "true" ]; then
+if [ "$autoStart" = "true" ] && [ "$enableVideoScript" = "true" ]; then
 	echo "Automatic Start Enabled, starting in 2 min..."
 	sleep 2m
 	bash /config/extended/scripts/start_video.sh

--- a/root/scripts/audio.sh
+++ b/root/scripts/audio.sh
@@ -1,13 +1,15 @@
 #!/usr/bin/env bash
 scriptVersion="1.0.216"
-lidarrUrlBase="$(cat /config/config.xml | xq | jq -r .Config.UrlBase)"
-if [ "$lidarrUrlBase" = "null" ]; then
-	lidarrUrlBase=""
-else
-	lidarrUrlBase="/$(echo "$lidarrUrlBase" | sed "s/\///g")"
+if [ -z "$lidarrUrl" ] || [ -z "$lidarrApiKey" ]; then
+	lidarrUrlBase="$(cat /config/config.xml | xq | jq -r .Config.UrlBase)"
+	if [ "$lidarrUrlBase" = "null" ]; then
+		lidarrUrlBase=""
+	else
+		lidarrUrlBase="/$(echo "$lidarrUrlBase" | sed "s/\///g")"
+	fi
+	lidarrApiKey="$(cat /config/config.xml | xq | jq -r .Config.ApiKey)"
+	lidarrUrl="http://127.0.0.1:8686${lidarrUrlBase}"
 fi
-lidarrApiKey="$(cat /config/config.xml | xq | jq -r .Config.ApiKey)"
-lidarrUrl="http://127.0.0.1:8686${lidarrUrlBase}"
 agent="lidarr-extended ( https://github.com/RandomNinjaAtk/docker-lidarr-extended )"
 musicbrainzMirror=https://musicbrainz.org
 

--- a/root/scripts/video.sh
+++ b/root/scripts/video.sh
@@ -1,13 +1,17 @@
 #!/usr/bin/env bash
 scriptVersion="1.0.008"
-lidarrUrlBase="$(cat /config/config.xml | xq | jq -r .Config.UrlBase)"
-if [ "$lidarrUrlBase" = "null" ]; then
-	lidarrUrlBase=""
-else
-	lidarrUrlBase="/$(echo "$lidarrUrlBase" | sed "s/\///g")"
+
+if [ -z "$lidarrUrl" ] || [ -z "$lidarrApiKey" ]; then
+	lidarrUrlBase="$(cat /config/config.xml | xq | jq -r .Config.UrlBase)"
+	if [ "$lidarrUrlBase" = "null" ]; then
+		lidarrUrlBase=""
+	else
+		lidarrUrlBase="/$(echo "$lidarrUrlBase" | sed "s/\///g")"
+	fi
+	lidarrApiKey="$(cat /config/config.xml | xq | jq -r .Config.ApiKey)"
+	lidarrUrl="http://127.0.0.1:8686${lidarrUrlBase}"
 fi
-lidarrApiKey="$(cat /config/config.xml | xq | jq -r .Config.ApiKey)"
-lidarrUrl="http://127.0.0.1:8686${lidarrUrlBase}"
+
 agent="lidarr-extended ( https://github.com/RandomNinjaAtk/docker-lidarr-extended )"
 musicbrainzMirror=https://musicbrainz.org
 


### PR DESCRIPTION
Check if audio/video script is enabled before starting the sleep-loop. Otherwise there will be a logentry every scriptInterval that the script is now starting.
And allowing to define a lidarrurl/token to connect to a remote lidarr instance. This wont allow autoupdates for this lidarr instance but you will get the downloaded music/videos. Handy if you're running multiple instances or, like me, download videos on another machine than the audio.