### PR TITLE
Add videoDownloadTag to limit artist downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Container images are configured using parameters passed at runtime (such as thos
 | `-e scriptInterval=15m` | #s or #m or #h or #d :: s = seconds, m = minutes, h = hours, d = days :: Amount of time between each script run, when autoStart is enabled |
 | `-e enableAudioScript=true` | true = enabled :: Enables the Audio script to run automatically |
 | `-e enableVideoScript=true` | true = enabled :: Enables the Video script to run automatically |
+| `-e videoDownloadTag=VALUE` | If VALUE is specified, only artists tagged with VALUE will have videos downloaded |
 | `-e configureLidarrWithOptimalSettings=true` | true = enabled :: Automatically configures Lidarr with optimal settings |
 | `-e searchSort=date` | date or album :: Sorts the missing/cutoff list by release date (newest -> oldest) or album type (album -> single) for processing the list |
 | `-e audioFormat=native` | native or alac or mp3 or aac or opus :: native is the native download client file type, selected by the matching audio bitrate |

--- a/amd64.dockerfile
+++ b/amd64.dockerfile
@@ -30,6 +30,7 @@ ENV enableVideoScript=true
 ENV matchDistance=5
 ENV scriptInterval=15m
 ENV videoFormat="bestvideo*+bestaudio/best"
+ENV videoDownloadTag=""
 
 RUN \
 	echo "*** install packages ***" && \

--- a/arm32v7.dockerfile
+++ b/arm32v7.dockerfile
@@ -40,6 +40,7 @@ ENV enableVideoScript=true
 ENV matchDistance=5
 ENV videoFormat="bestvideo*+bestaudio/best"
 ENV scriptInterval=15m
+ENV videoDownloadTag=""
 
 RUN \
 	echo "*** install packages ***" && \

--- a/arm64v8.dockerfile
+++ b/arm64v8.dockerfile
@@ -40,6 +40,7 @@ ENV enableVideoScript=true
 ENV matchDistance=5
 ENV videoFormat="bestvideo*+bestaudio/best"
 ENV scriptInterval=15m
+ENV videoDownloadTag=""
 
 RUN \
 	echo "*** install packages ***" && \

--- a/root/scripts/Audio.sh
+++ b/root/scripts/Audio.sh
@@ -1638,11 +1638,6 @@ ArtistTidalSearch () {
 	# $3 Lyric Type (true or false) - false = Clean, true = Explicit
 
 	# Get tidal artist album list
-	if [ ! -f /config/extended/cache/tidal/$2-videos.json ]; then
-		curl -s "https://api.tidal.com/v1/artists/$2/videos?limit=10000&countryCode=$tidalCountryCode&filter=ALL" -H 'x-tidal-token: CzET4vdadNUFQ5JU' > /config/extended/cache/tidal/$2-videos.json
-		sleep $sleepTimer
-	fi
-
 	if [ ! -f /config/extended/cache/tidal/$2-albums.json ]; then
 		curl -s "https://api.tidal.com/v1/artists/$2/albums?limit=10000&countryCode=$tidalCountryCode&filter=ALL" -H 'x-tidal-token: CzET4vdadNUFQ5JU' > /config/extended/cache/tidal/$2-albums.json
 		sleep $sleepTimer

--- a/root/scripts/Video.sh
+++ b/root/scripts/Video.sh
@@ -87,6 +87,9 @@ Configuration () {
 	log "CONFIG :: Music Video Location :: $videoPath"
 	log "CONFIG :: Subtitle Language set to: $youtubeSubtitleLanguage"
 	log "CONFIG :: yt-dlp format: $videoFormat"
+	if [ -n "$videoDownloadTag" ]; then
+		log "CONFIG :: Video download tag set to: $videoDownloadTag"
+	fi
 	if [ -f "/config/cookies.txt" ]; then
 		cookiesFile="/config/cookies.txt"
 		log "CONFIG :: Cookies File Found! (/config/cookies.txt)"
@@ -591,8 +594,13 @@ AddFeaturedVideoArtists
 log "-----------------------------------------------------------------------------"
 log "Finding Videos"    
 log "-----------------------------------------------------------------------------"
-lidarrArtists=$(wget --timeout=0 -q -O - "$lidarrUrl/api/v1/artist?apikey=$lidarrApiKey" | jq -r .[])
-lidarrArtistIds=$(echo $lidarrArtists | jq -r .id)
+if [ -z "$videoDownloadTag" ]; then
+	lidarrArtists=$(wget --timeout=0 -q -O - "$lidarrUrl/api/v1/artist?apikey=$lidarrApiKey" | jq -r .[])
+	lidarrArtistIds=$(echo $lidarrArtists | jq -r .id)
+else
+	lidarrArtists=$(curl -s "$lidarrUrl/api/v1/tag/detail" -H 'Content-Type: application/json' -H "X-Api-Key: $lidarrApiKey" | jq -r -M ".[] | select(.label == \"$videoDownloadTag\") | .artistIds")
+	lidarrArtistIds=$(echo $lidarrArtists | jq -r .[])
+fi
 lidarrArtistIdsCount=$(echo "$lidarrArtistIds" | wc -l)
 processCount=0
 for lidarrArtistId in $(echo $lidarrArtistIds); do


### PR DESCRIPTION
Per discussion on #141, this PR adds the ability to specify a videoDownloadTag. If a value is specified for videoDownloadTag, only artists tagged in Lidarr with the specified tag will have videos downloaded for them. If videoDownloadTag is left empty (the default), things work exactly as they did prior to introducing this feature.