### PR TITLE
Enable Beets lastgenre plugin

### DIFF
--- a/amd64.dockerfile
+++ b/amd64.dockerfile
@@ -56,6 +56,7 @@ RUN \
 		pyacoustid \
 		requests \
 		beets \
+		pylast \
 		mutagen \
 		r128gain \
 		tidal-dl \

--- a/arm32v7.dockerfile
+++ b/arm32v7.dockerfile
@@ -68,6 +68,7 @@ RUN \
 		pyacoustid \
 		requests \
 		beets \
+		pylast \
 		mutagen \
 		r128gain \
 		tidal-dl \

--- a/arm64v8.dockerfile
+++ b/arm64v8.dockerfile
@@ -68,6 +68,7 @@ RUN \
 		pyacoustid \
 		requests \
 		beets \
+		pylast \
 		mutagen \
 		r128gain \
 		tidal-dl \

--- a/root/scripts/beets-config.yaml
+++ b/root/scripts/beets-config.yaml
@@ -1,4 +1,4 @@
-plugins: chroma embedart
+plugins: chroma embedart lastgenre
 art_filename: folder
 threaded: no
 per_disc_numbering: yes
@@ -70,3 +70,16 @@ chroma:
 
 embedart:
     auto: no
+
+lastgenre:
+    auto: yes
+    canonical: yes
+    count: 1
+    fallback: None
+    force: yes
+    min_weight: 10
+    prefer_specific: no
+    source: album
+    separator: ', '
+    whitelist: /config/extended/scripts/beets-genre-whitelist.txt
+    title_case: yes

--- a/root/scripts/beets-genre-whitelist.txt
+++ b/root/scripts/beets-genre-whitelist.txt
@@ -1,0 +1,1541 @@
+2 tone
+2-step garage
+4-beat
+4x4 garage
+8-bit
+acapella
+acid
+acid breaks
+acid house
+acid jazz
+acid rock
+acoustic music
+acousticana
+adult contemporary music
+african popular music
+african rumba
+afrobeat
+aleatoric music
+alternative country
+alternative dance
+alternative hip hop
+alternative metal
+alternative rock
+ambient
+ambient house
+ambient music
+americana
+anarcho punk
+anti-folk
+apala
+ape haters
+arab pop
+arabesque
+arabic pop
+argentine rock
+ars antiqua
+ars nova
+art punk
+art rock
+ashiq
+asian american jazz
+australian country music
+australian hip hop
+australian pub rock
+austropop
+avant-garde
+avant-garde jazz
+avant-garde metal
+avant-garde music
+axé
+bac-bal
+bachata
+baggy
+baila
+baile funk
+baisha xiyue
+baithak gana
+baião
+bajourou
+bakersfield sound
+bakou
+bakshy
+bal-musette
+balakadri
+balinese gamelan
+balkan pop
+ballad
+ballata
+ballet
+bamboo band
+bambuco
+banda
+bangsawan
+bantowbol
+barbershop music
+barndance
+baroque
+baroque music
+baroque pop
+bass music
+batcave
+batucada
+batuco
+batá-rumba
+beach music
+beat
+beatboxing
+beautiful music
+bebop
+beiguan
+bel canto
+bend-skin
+benga
+berlin school of electronic music
+bhajan
+bhangra
+bhangra-wine
+bhangragga
+bhangramuffin
+big band
+big band music
+big beat
+biguine
+bihu
+bikutsi
+biomusic
+bitcore
+bitpop
+black metal
+blackened death metal
+blue-eyed soul
+bluegrass
+blues
+blues ballad
+blues-rock
+boogie
+boogie woogie
+boogie-woogie
+bossa nova
+brass band
+brazilian funk
+brazilian jazz
+breakbeat
+breakbeat hardcore
+breakcore
+breton music
+brill building pop
+britfunk
+british blues
+british invasion
+britpop
+broken beat
+brown-eyed soul
+brukdown
+brutal death metal
+bubblegum dance
+bubblegum pop
+bulerias
+bumba-meu-boi
+bunraku
+burger-highlife
+burgundian school
+byzantine chant
+ca din tulnic
+ca pe lunca
+ca trù
+cabaret
+cadence
+cadence rampa
+cadence-lypso
+café-aman
+cai luong
+cajun music
+cakewalk
+calenda
+calentanos
+calgia
+calypso
+calypso jazz
+calypso-style baila
+campursari
+canatronic
+candombe
+canon
+canrock
+cantata
+cante chico
+cante jondo
+canterbury scene
+cantiga
+cantique
+cantiñas
+canto livre
+canto nuevo
+canto popular
+cantopop
+canzone napoletana
+cape jazz
+capoeira music
+caracoles
+carceleras
+cardas
+cardiowave
+carimbó
+cariso
+carnatic music
+carol
+cartageneras
+cassette culture
+casséy-co
+cavacha
+caveman
+caña
+celempungan
+cello rock
+celtic
+celtic fusion
+celtic metal
+celtic punk
+celtic reggae
+celtic rock
+cha-cha-cha
+chakacha
+chalga
+chamamé
+chamber jazz
+chamber music
+chamber pop
+champeta
+changuí
+chanson
+chant
+charanga
+charanga-vallenata
+charikawi
+chastushki
+chau van
+chemical breaks
+chicago blues
+chicago house
+chicago soul
+chicano rap
+chicha
+chicken scratch
+children's music
+chillout
+chillwave
+chimurenga
+chinese music
+chinese pop
+chinese rock
+chip music
+cho-kantrum
+chongak
+chopera
+chorinho
+choro
+chouval bwa
+chowtal
+christian alternative
+christian black metal
+christian electronic music
+christian hardcore
+christian hip hop
+christian industrial
+christian metal
+christian music
+christian punk
+christian r&b
+christian rock
+christian ska
+christmas carol
+christmas music
+chumba
+chut-kai-pang
+chutney
+chutney soca
+chutney-bhangra
+chutney-hip hop
+chutney-soca
+chylandyk
+chzalni
+chèo
+cigányzene
+classic
+classic country
+classic female blues
+classic rock
+classical
+classical music
+classical music era
+clicks n cuts
+close harmony
+club music
+cocobale
+coimbra fado
+coladeira
+colombianas
+combined rhythm
+comedy
+comedy rap
+comedy rock
+comic opera
+comparsa
+compas direct
+compas meringue
+concert overture
+concerto
+concerto grosso
+congo
+conjunto
+contemporary christian
+contemporary christian music
+contemporary classical
+contemporary r&b
+contonbley
+contradanza
+cool jazz
+corrido
+corsican polyphonic song
+cothoza mfana
+country
+country blues
+country gospel
+country music
+country pop
+country r&b
+country rock
+country-rap
+countrypolitan
+couple de sonneurs
+coupé-décalé
+cowpunk
+cretan music
+crossover jazz
+crossover music
+crossover thrash
+crossover thrash metal
+crunk
+crunk&b
+crunkcore
+crust punk
+csárdás
+cuarteto
+cuban rumba
+cuddlecore
+cueca
+cumbia
+cumbia villera
+cybergrind
+dabka
+dadra
+daina
+dalauna
+dance
+dance music
+dance-pop
+dance-punk
+dance-rock
+dancehall
+dangdut
+danger music
+dansband
+danza
+danzón
+dark ambient
+dark cabaret
+dark pop
+darkcore
+darkstep
+darkwave
+de ascultat la servici
+de codru
+de dragoste
+de jale
+de pahar
+death industrial
+death metal
+death rock
+death/doom
+deathcore
+deathgrind
+deathrock
+deep funk
+deep house
+deep soul
+degung
+delta blues
+dementia
+desert rock
+desi
+detroit blues
+detroit techno
+dhamar
+dhimotiká
+dhrupad
+dhun
+digital hardcore
+dirge
+dirty dutch
+dirty rap
+dirty rap/pornocore
+dirty south
+disco
+disco house
+disco polo
+disney
+disney hardcore
+disney pop
+diva house
+divine rock
+dixieland
+dixieland jazz
+djambadon
+djent
+dodompa
+doina
+dombola
+dondang sayang
+donegal fiddle tradition
+dongjing
+doo wop
+doom metal
+doomcore
+downtempo
+drag
+dream pop
+drone doom
+drone metal
+drone music
+dronology
+drum and bass
+dub
+dub house
+dubanguthu
+dubstep
+dubtronica
+dunedin sound
+dunun
+dutch jazz
+décima
+early music
+east coast blues
+east coast hip hop
+easy listening
+electric blues
+electric folk
+electro
+electro backbeat
+electro hop
+electro house
+electro punk
+electro-industrial
+electro-swing
+electroclash
+electrofunk
+electronic
+electronic art music
+electronic body music
+electronic dance
+electronic luk thung
+electronic music
+electronic rock
+electronica
+electropop
+elevator music
+emo
+emo pop
+emo rap
+emocore
+emotronic
+enka
+epic doom metal
+epic metal
+eremwu eu
+ethereal pop
+ethereal wave
+euro
+euro disco
+eurobeat
+eurodance
+europop
+eurotrance
+eurourban
+exotica
+experimental music
+experimental noise
+experimental pop
+experimental rock
+extreme metal
+ezengileer
+fado
+falak
+fandango
+farruca
+fife and drum blues
+filk
+film score
+filmi
+filmi-ghazal
+finger-style
+fjatpangarri
+flamenco
+flamenco rumba
+flower power
+foaie verde
+fofa
+folk hop
+folk metal
+folk music
+folk pop
+folk punk
+folk rock
+folktronica
+forró
+franco-country
+freak-folk
+freakbeat
+free improvisation
+free jazz
+free music
+freestyle
+freestyle house
+freetekno
+french pop
+frenchcore
+frevo
+fricote
+fuji
+fuji music
+fulia
+full on
+funaná
+funeral doom
+funk
+funk metal
+funk rock
+funkcore
+funky house
+furniture music
+fusion jazz
+g-funk
+gaana
+gabba
+gabber
+gagaku
+gaikyoku
+gaita
+galant
+gamad
+gambang kromong
+gamelan
+gamelan angklung
+gamelan bang
+gamelan bebonangan
+gamelan buh
+gamelan degung
+gamelan gede
+gamelan kebyar
+gamelan salendro
+gamelan selunding
+gamelan semar pegulingan
+gamewave
+gammeldans
+gandrung
+gangsta rap
+gar
+garage rock
+garrotin
+gavotte
+gelugpa chanting
+gender wayang
+gending
+german folk music
+gharbi
+gharnati
+ghazal
+ghazal-song
+ghetto house
+ghettotech
+girl group
+glam metal
+glam punk
+glam rock
+glitch
+gnawa
+go-go
+goa
+goa trance
+gong-chime music
+goombay
+goregrind
+goshu ondo
+gospel music
+gothic metal
+gothic rock
+granadinas
+grebo
+gregorian chant
+grime
+grindcore
+groove metal
+group sounds
+grunge
+grupera
+guaguanbo
+guajira
+guasca
+guitarra baiana
+guitarradas
+gumbe
+gunchei
+gunka
+guoyue
+gwo ka
+gwo ka moderne
+gypsy jazz
+gypsy punk
+gypsybilly
+gyu ke
+habanera
+hajnali
+hakka
+halling
+hambo
+hands up
+hapa haole
+happy hardcore
+haqibah
+hard
+hard bop
+hard house
+hard rock
+hard trance
+hardcore hip hop
+hardcore metal
+hardcore punk
+hardcore techno
+hardstyle
+harepa
+harmonica blues
+hasaposérviko
+heart attack
+heartland rock
+heavy beat
+heavy metal
+hesher
+hi-nrg
+highlands
+highlife
+highlife fusion
+hillybilly music
+hindustani classical music
+hip hop
+hip hop & rap
+hip hop soul
+hip house
+hiplife
+hiragasy
+hiva usu
+hong kong and cantonese pop
+hong kong english pop
+honky tonk
+honkyoku
+hora lunga
+hornpipe
+horror punk
+horrorcore
+horrorcore rap
+house
+house music
+hua'er
+huasteco
+huayno
+hula
+humor
+humppa
+hunguhungu
+hyangak
+hymn
+hyphy
+hát chau van
+hát chèo
+hát cãi luong
+hát tuồng
+ibiza music
+icaro
+idm
+igbo music
+ijexá
+ilahije
+illbient
+impressionist music
+improvisational
+incidental music
+indian pop
+indie folk
+indie music
+indie pop
+indie rock
+indietronica
+indo jazz
+indo rock
+indonesian pop
+indoyíftika
+industrial death metal
+industrial hip-hop
+industrial metal
+industrial music
+industrial musical
+industrial rock
+instrumental rock
+intelligent dance music
+international latin
+inuit music
+iranian pop
+irish folk
+irish rebel music
+iscathamiya
+isicathamiya
+isikhwela jo
+island
+isolationist
+italo dance
+italo disco
+italo house
+itsmeños
+izvorna bosanska muzika
+j'ouvert
+j-fusion
+j-pop
+j-rock
+jaipongan
+jaliscienses
+jam band
+jam rock
+jamana kura
+jamrieng samai
+jangle pop
+japanese pop
+jarana
+jariang
+jarochos
+jawaiian
+jazz
+jazz blues
+jazz fusion
+jazz metal
+jazz rap
+jazz-funk
+jazz-rock
+jegog
+jenkka
+jesus music
+jibaro
+jig
+jig punk
+jing ping
+jingle
+jit
+jitterbug
+jive
+joged
+joged bumbung
+joik
+jonnycore
+joropo
+jota
+jtek
+jug band
+jujitsu
+juju
+juke joint blues
+jump blues
+jumpstyle
+jungle
+junkanoo
+juré
+jùjú
+k-pop
+kaba
+kabuki
+kachāshī
+kadans
+kagok
+kagyupa chanting
+kaiso
+kalamatianó
+kalattuut
+kalinda
+kamba pop
+kan ha diskan
+kansas city blues
+kantrum
+kantádhes
+kargyraa
+karma
+kaseko
+katajjaq
+kawachi ondo
+kayōkyoku
+ke-kwe
+kebyar
+kecak
+kecapi suling
+kertok
+khaleeji
+khap
+khelimaski djili
+khene
+khoomei
+khorovodi
+khplam wai
+khrung sai
+khyal
+kilapanda
+kinko
+kirtan
+kiwi rock
+kizomba
+klape
+klasik
+klezmer
+kliningan
+kléftiko
+kochare
+kolomyjka
+komagaku
+kompa
+konpa
+korean pop
+koumpaneia
+kpanlogo
+krakowiak
+krautrock
+kriti
+kroncong
+krump
+krzesany
+kuduro
+kulintang
+kulning
+kumina
+kun-borrk
+kundere
+kundiman
+kussundé
+kutumba wake
+kveding
+kvæði
+kwaito
+kwassa kwassa
+kwela
+käng
+kélé
+kĩkũyũ pop
+la la
+latin american
+latin jazz
+latin pop
+latin rap
+lavway
+laïko
+laïkó
+le leagan
+legényes
+lelio
+letkajenkka
+levenslied
+lhamo
+lieder
+light music
+light rock
+likanos
+liquid drum&bass
+liquid funk
+liquindi
+llanera
+llanto
+lo-fi
+lo-fi music
+loki djili
+long-song
+louisiana blues
+louisiana swamp pop
+lounge music
+lovers rock
+lowercase
+lubbock sound
+lucknavi thumri
+luhya omutibo
+luk grung
+lullaby
+lundu
+lundum
+m-base
+madchester
+madrigal
+mafioso rap
+maglaal
+magnificat
+mahori
+mainstream jazz
+makossa
+makossa-soukous
+malagueñas
+malawian jazz
+malhun
+maloya
+maluf
+maluka
+mambo
+manaschi
+mandarin pop
+manding swing
+mango
+mangue bit
+mangulina
+manikay
+manila sound
+manouche
+manzuma
+mapouka
+mapouka-serré
+marabi
+maracatu
+marga
+mariachi
+marimba
+marinera
+marrabenta
+martial industrial
+martinetes
+maskanda
+mass
+matamuerte
+math rock
+mathcore
+matt bello
+maxixe
+mazurka
+mbalax
+mbaqanga
+mbube
+mbumba
+medh
+medieval folk rock
+medieval metal
+medieval music
+meditation
+mejorana
+melhoun
+melhûn
+melodic black metal
+melodic death metal
+melodic hardcore
+melodic metalcore
+melodic music
+melodic trance
+memphis blues
+memphis rap
+memphis soul
+mento
+merengue
+merengue típico moderno
+merengue-bomba
+meringue
+merseybeat
+metal
+metalcore
+metallic hardcore
+mexican pop
+mexican rock
+mexican son
+meykhana
+mezwed
+miami bass
+microhouse
+middle of the road
+midwest hip hop
+milonga
+min'yo
+mineras
+mini compas
+mini-jazz
+minimal techno
+minimalist music
+minimalist trance
+minneapolis sound
+minstrel show
+minuet
+mirolóyia
+modal jazz
+modern classical
+modern classical music
+modern laika
+modern rock
+modinha
+mohabelo
+montuno
+monumental dance
+mor lam
+mor lam sing
+morna
+motorpop
+motown
+mozambique
+mpb
+mugam
+multicultural
+murga
+musette
+museve
+mushroom jazz
+music drama
+music hall
+musiqi-e assil
+musique concrète
+mutuashi
+muwashshah
+muzak
+méringue
+música campesina
+música criolla
+música de la interior
+música llanera
+música nordestina
+música popular brasileira
+música tropical
+nagauta
+nakasi
+nangma
+nanguan
+narcocorrido
+nardcore
+narodna muzika
+nasheed
+nashville sound
+nashville sound/countrypolitan
+national socialist black metal
+naturalismo
+nederpop
+neo soul
+neo-classical metal
+neo-medieval
+neo-prog
+neo-psychedelia
+neoclassical
+neoclassical metal
+neoclassical music
+neofolk
+neotraditional country
+nerdcore
+neue deutsche härte
+neue deutsche welle
+new age music
+new beat
+new instrumental
+new jack swing
+new orleans blues
+new orleans jazz
+new pop
+new prog
+new rave
+new romantic
+new school hip hop
+new taiwanese song
+new wave
+new wave of british heavy metal
+new wave of new wave
+new weird america
+new york blues
+new york house
+newgrass
+nganja
+nightcore
+nintendocore
+nisiótika
+no wave
+noh
+noise music
+noise pop
+noise rock
+nongak
+norae undong
+nordic folk dance music
+nordic folk music
+nortec
+norteño
+northern soul
+nota
+nu breaks
+nu jazz
+nu metal
+nu soul
+nueva canción
+nyatiti
+néo kýma
+obscuro
+oi!
+old school hip hop
+old-time
+oldies
+olonkho
+oltului
+ondo
+opera
+operatic pop
+oratorio
+orchestra
+orchestral
+organ trio
+organic ambient
+organum
+orgel
+oriental metal
+ottava rima
+outlaw country
+outsider music
+p-funk
+pagan metal
+pagan rock
+pagode
+paisley underground
+palm wine
+palm-wine
+pambiche
+panambih
+panchai baja
+panchavadyam
+pansori
+paranda
+parang
+parody
+parranda
+partido alto
+pasillo
+patriotic
+peace punk
+pelimanni music
+petenera
+peyote song
+philadelphia soul
+piano blues
+piano rock
+piedmont blues
+pimba
+pinoy pop
+pinoy rock
+pinpeat orchestra
+piphat
+piyyutim
+plainchant
+plena
+pleng phua cheewit
+pleng thai sakorn
+political hip hop
+polka
+polo
+polonaise
+pols
+polska
+pong lang
+pop
+pop folk
+pop music
+pop punk
+pop rap
+pop rock
+pop sunda
+pornocore
+porro
+post disco
+post-britpop
+post-disco
+post-grunge
+post-hardcore
+post-industrial
+post-metal
+post-minimalism
+post-punk
+post-rock
+post-romanticism
+pow-wow
+power electronics
+power metal
+power noise
+power pop
+powerviolence
+ppongtchak
+praise song
+program symphony
+progressive bluegrass
+progressive country
+progressive death metal
+progressive electronic
+progressive electronic music
+progressive folk
+progressive folk music
+progressive house
+progressive metal
+progressive power metal
+progressive rock
+progressive trance
+progressive thrash metal
+protopunk
+psych folk
+psychedelic music
+psychedelic pop
+psychedelic rock
+psychedelic trance
+psychobilly
+punk blues
+punk cabaret
+punk jazz
+punk rock
+punta
+punta rock
+qasidah
+qasidah modern
+qawwali
+quadrille
+quan ho
+queercore
+quiet storm
+rada
+raga
+raga rock
+ragga
+ragga jungle
+raggamuffin
+ragtime
+rai
+rake-and-scrape
+ramkbach
+ramvong
+ranchera
+rap
+rap metal
+rap rock
+rapcore
+rara
+rare groove
+rasiya
+rave
+raw rock
+raï
+rebetiko
+red dirt
+reel
+reggae
+reggae 110
+reggae bultrón
+reggae en español
+reggae fusion
+reggae highlife
+reggaefusion
+reggaeton
+rekilaulu
+relax music
+religious
+rembetiko
+renaissance music
+requiem
+rhapsody
+rhyming spiritual
+rhythm & blues
+rhythm and blues
+ricercar
+riot grrrl
+rock
+rock and roll
+rock en español
+rock opera
+rockabilly
+rocksteady
+rococo
+romantic flow
+romantic period in music
+rondeaux
+ronggeng
+roots reggae
+roots rock
+roots rock reggae
+rumba
+russian pop
+rímur
+sabar
+sacred harp
+sacred music
+sadcore
+saibara
+sakara
+salegy
+salsa
+salsa erotica
+salsa romantica
+saltarello
+samba
+samba-canção
+samba-reggae
+samba-rock
+sambai
+sanjo
+sato kagura
+sawt
+saya
+scat
+schlager
+schottisch
+schranz
+scottish baroque music
+screamo
+scrumpy and western
+sea shanty
+sean nós
+second viennese school
+sega music
+seggae
+seis
+semba
+sephardic music
+serialism
+set dance
+sevdalinka
+sevillana
+shabab
+shabad
+shalako
+shan'ge
+shango
+shape note
+shibuya-kei
+shidaiqu
+shima uta
+shock rock
+shoegaze
+shoegazer
+shoka
+shomyo
+show tune
+sica
+siguiriyas
+silat
+sinawi
+situational
+ska
+ska punk
+skacore
+skald
+skate punk
+skiffle
+slack-key guitar
+slide
+slowcore
+sludge metal
+slängpolska
+smooth jazz
+soca
+soft rock
+son
+son montuno
+son-batá
+sonata
+songo
+songo-salsa
+sophisti-pop
+soukous
+soul
+soul blues
+soul jazz
+soul music
+southern gospel
+southern harmony
+southern hip hop
+southern metal
+southern rock
+southern soul
+space age pop
+space music
+space rock
+spectralism
+speed garage
+speed metal
+speedcore
+spirituals
+spouge
+sprechgesang
+square dance
+squee
+st. louis blues
+stand-up
+steelband
+stoner metal
+stoner rock
+straight edge
+strathspeys
+stride
+string
+string quartet
+sufi music
+suite
+sunshine pop
+suomirock
+super eurobeat
+surf ballad
+surf instrumental
+surf music
+surf pop
+surf rock
+swamp blues
+swamp pop
+swamp rock
+swing
+swing music
+swingbeat
+sygyt
+symphonic
+symphonic black metal
+symphonic metal
+symphonic poem
+symphonic rock
+symphony
+synthcore
+synthpop
+synthpunk
+t'ong guitar
+taarab
+tai tu
+taiwanese pop
+tala
+talempong
+tambu
+tamburitza
+tamil christian keerthanai
+tango
+tanguk
+tappa
+tarana
+tarantella
+taranto
+tech
+tech house
+tech trance
+technical death metal
+technical metal
+techno
+technoid
+technopop
+techstep
+techtonik
+teen pop
+tejano
+tejano music
+tekno
+tembang sunda
+teutonic thrash metal
+texas blues
+thai pop
+thillana
+thrash metal
+thrashcore
+thumri
+tibetan pop
+tiento
+timbila
+tin pan alley
+tinga
+tinku
+toeshey
+togaku
+trad jazz
+traditional bluegrass
+traditional heavy metal
+traditional pop music
+trallalero
+trance
+tribal house
+trikitixa
+trip hop
+trip rock
+tropicalia
+tropicalismo
+tropipop
+truck-driving country
+tumba
+turbo-folk
+turkish music
+turkish pop
+turntablism
+tuvan throat-singing
+twee pop
+twist
+two tone
+táncház
+uk garage
+uk pub rock
+unblack metal
+underground music
+uplifting
+uplifting trance
+urban cowboy
+urban folk
+urban jazz
+vallenato
+vaudeville
+venezuela
+verbunkos
+verismo
+viking metal
+villanella
+virelai
+vispop
+visual kei
+visual music
+vocal
+vocal house
+vocal jazz
+vocal music
+volksmusik
+waila
+waltz
+wangga
+warabe uta
+wassoulou
+weld
+were music
+west coast hip hop
+west coast jazz
+western
+western blues
+western swing
+witch house
+wizard rock
+women's music
+wong shadow
+wonky pop
+wood
+work song
+world fusion
+world fusion music
+world music
+worldbeat
+xhosa music
+xoomii
+yo-pop
+yodeling
+yukar
+yé-yé
+zajal
+zapin
+zarzuela
+zeibekiko
+zeuhl
+ziglibithy
+zouglou
+zouk
+zouk chouv
+zouklove
+zulu music
+zydeco


### PR DESCRIPTION
This will pull the single most popular tag on last.fm for the album that is included in a whitelist located in the scripts directory.

If the user does not edit the whitelist, lidarr-extended's behavior does not change as the whitelist is an exact copy of what beets already uses.

However, if the user does remove items from the whitelist, then the popular tags from last.fm are compared to a canonicalization tree and what is remaining in the whitelist opting for the most specific leaf in the tree.

I have configured this to be almost completely default in nature but allow the end user to customize which genres to include within their own libraries.

For reference: [LastGenre Plugin](https://beets.readthedocs.io/en/stable/plugins/lastgenre.html)