### PR TITLE
Try to fix ARM build errors

### DIFF
--- a/arm32v7.dockerfile
+++ b/arm32v7.dockerfile
@@ -60,7 +60,7 @@ RUN \
 		libc-dev \
 		py3-pip \
 		rust \
-                cargo \
+        cargo \
 		yt-dlp && \
 	echo "*** install python packages ***" && \
 	pip install --upgrade --no-cache-dir \
@@ -86,7 +86,8 @@ RUN \
 	chmod g+w ${SMA_PATH}/config/sma.log && \
 	echo "************ install pip dependencies ************" && \
 	python3 -m pip install --user --upgrade pip && \	
-	pip3 install -r ${SMA_PATH}/setup/requirements.txt
+	pip3 install -r ${SMA_PATH}/setup/requirements.txt && \
+	apk del cargo rust
 
 # copy local files
 COPY root/ /

--- a/arm64v8.dockerfile
+++ b/arm64v8.dockerfile
@@ -59,8 +59,8 @@ RUN \
 		python3-dev \
 		libc-dev \
 		py3-pip \
-                rust \
-                cargo \
+        rust \
+        cargo \
 		yt-dlp && \
 	echo "*** install python packages ***" && \
 	pip install --upgrade --no-cache-dir \
@@ -86,7 +86,8 @@ RUN \
 	chmod g+w ${SMA_PATH}/config/sma.log && \
 	echo "************ install pip dependencies ************" && \
 	python3 -m pip install --user --upgrade pip && \	
-	pip3 install -r ${SMA_PATH}/setup/requirements.txt
+	pip3 install -r ${SMA_PATH}/setup/requirements.txt && \
+	apk del cargo rust
 
 # copy local files
 COPY root/ /


### PR DESCRIPTION
You may have noticed the ARM builds are failing again: I don't know why, but a guess is that they are way to big. Without the apk del my testimages are ~2gb. Now they are again < 1gb and maybe it works again in the dockerhub build. But it's just a try...