### PR TITLE
Add beets image handling support

### DIFF
--- a/amd64.dockerfile
+++ b/amd64.dockerfile
@@ -45,6 +45,7 @@ RUN \
 		git \
 		gcc \
 		ffmpeg \
+		imagemagick \
 		opus-tools \
 		python3-dev \
 		libc-dev \

--- a/arm32v7.dockerfile
+++ b/arm32v7.dockerfile
@@ -56,6 +56,7 @@ RUN \
 		gcc \
 		opus-tools \
 		ffmpeg \
+		imagemagick \
 		python3-dev \
 		libc-dev \
 		py3-pip \

--- a/arm64v8.dockerfile
+++ b/arm64v8.dockerfile
@@ -56,6 +56,7 @@ RUN \
 		gcc \
 		opus-tools \
 		ffmpeg \
+		imagemagick \
 		python3-dev \
 		libc-dev \
 		py3-pip \

--- a/root/scripts/Audio.sh
+++ b/root/scripts/Audio.sh
@@ -567,8 +567,10 @@ DownloadProcess () {
 		log "$page :: $wantedAlbumListSource :: $processNumber of $wantedListAlbumTotal :: $lidarrArtistName :: $lidarrAlbumTitle :: $lidarrAlbumType :: Setting ARTIST/ALBUMARTIST tag to \"$lidarrArtistName\" :: $file"
 		metaflac --remove-tag=ALBUMARTIST "$file"
 		metaflac --remove-tag=ARTIST "$file"
+		metaflac --remove-tag=MUSICBRAINZ_ARTISTID "$file"
 		metaflac --set-tag=ALBUMARTIST="$lidarrArtistName" "$file"
 		metaflac --set-tag=ARTIST="$lidarrArtistName" "$file"
+		metaflac --set-tag=MUSICBRAINZ_ARTISTID="$lidarrArtistForeignArtistId" "$file"
 	done
 
 	# Tag with beets
@@ -739,8 +741,10 @@ ProcessWithBeets () {
 			metaflac --remove-tag="ALBUM ARTIST" "$file"
 			metaflac --remove-tag=ARTISTSORT "$file"
 			metaflac --remove-tag=ARTIST "$file"
+			metaflac --remove-tag=MUSICBRAINZ_ARTISTID "$file"
 			metaflac --set-tag=ARTIST="$lidarrArtistName" "$file"
 			metaflac --set-tag=ALBUMARTIST="$lidarrArtistName" "$file"
+			metaflac --set-tag=MUSICBRAINZ_ARTISTID="$lidarrArtistForeignArtistId" "$file"
 		done
 	else
 		log "$page :: $wantedAlbumListSource :: $processNumber of $wantedListAlbumTotal :: $lidarrArtistName :: $lidarrAlbumTitle :: $lidarrAlbumType :: ERROR :: Unable to match using beets to a musicbrainz release..."

--- a/root/scripts/beets-config.yaml
+++ b/root/scripts/beets-config.yaml
@@ -1,4 +1,4 @@
-plugins: chroma embedart lastgenre
+plugins: chroma embedart lastgenre fetchart embedart
 art_filename: folder
 threaded: no
 per_disc_numbering: yes
@@ -83,3 +83,25 @@ lastgenre:
     separator: ', '
     whitelist: /config/extended/scripts/beets-genre-whitelist.txt
     title_case: yes
+
+fetchart:
+  auto: no
+  cautious: no
+  enforce_ratio: yes
+  minwidth: 1000
+  maxwidth: 3000
+  sources:
+    - filesystem
+    - coverart
+    - albumart
+    # - fanarttv
+    - bandcamp
+#   fanarttv_key: yourAPIkey
+  store_source: yes
+
+embedart:
+  auto: no
+  compare_threshold: 50
+  ifempty: yes
+  maxwidth: 0
+  remove_art_file: no


### PR DESCRIPTION
This will allow users to allow beets to both fetch and embed album cover artwork when "auto" modes are set in the respective beet plugins