### PR TITLE
Edge case tagging fix

### DIFF
--- a/root/scripts/Audio.sh
+++ b/root/scripts/Audio.sh
@@ -568,9 +568,11 @@ DownloadProcess () {
 		metaflac --remove-tag=ALBUMARTIST "$file"
 		metaflac --remove-tag=ARTIST "$file"
 		metaflac --remove-tag=MUSICBRAINZ_ARTISTID "$file"
+		metaflac --remove-tag=MUSICBRAINZ_ALBUMARTISTID "$file"
 		metaflac --set-tag=ALBUMARTIST="$lidarrArtistName" "$file"
 		metaflac --set-tag=ARTIST="$lidarrArtistName" "$file"
 		metaflac --set-tag=MUSICBRAINZ_ARTISTID="$lidarrArtistForeignArtistId" "$file"
+		metaflac --set-tag=MUSICBRAINZ_ALBUMARTISTID="$lidarrArtistForeignArtistId" "$file"
 	done
 
 	# Tag with beets
@@ -742,9 +744,11 @@ ProcessWithBeets () {
 			metaflac --remove-tag=ARTISTSORT "$file"
 			metaflac --remove-tag=ARTIST "$file"
 			metaflac --remove-tag=MUSICBRAINZ_ARTISTID "$file"
+			metaflac --remove-tag=MUSICBRAINZ_ALBUMARTISTID "$file"
 			metaflac --set-tag=ARTIST="$lidarrArtistName" "$file"
 			metaflac --set-tag=ALBUMARTIST="$lidarrArtistName" "$file"
 			metaflac --set-tag=MUSICBRAINZ_ARTISTID="$lidarrArtistForeignArtistId" "$file"
+			metaflac --set-tag=MUSICBRAINZ_ALBUMARTISTID="$lidarrArtistForeignArtistId" "$file"
 		done
 	else
 		log "$page :: $wantedAlbumListSource :: $processNumber of $wantedListAlbumTotal :: $lidarrArtistName :: $lidarrAlbumTitle :: $lidarrAlbumType :: ERROR :: Unable to match using beets to a musicbrainz release..."


### PR DESCRIPTION
In addition to the previous tagging fix #250 this one handles setting MusicBrainz `albumartistid`.  This only presents as a problem occasionally where artist id and album artist id are different.  This ensures artist mapping that matches Lidarr.